### PR TITLE
fix(bot): refactor keyboards, use 2 rows for buttons

### DIFF
--- a/src/bot/constants.py
+++ b/src/bot/constants.py
@@ -36,3 +36,7 @@ rules_message = (
     "⚠️ Unnecessarily, do not move the equipment.\n"
 )
 rules_confirmation_message = """I agree to and will abide by the stated rules."""
+
+create_booking_message = "Create a booking"
+my_bookings_message = "My bookings"
+image_schedule_message = "Show the image with bookings"

--- a/src/bot/menu.py
+++ b/src/bot/menu.py
@@ -1,12 +1,28 @@
 from aiogram import types
 
+from src.bot import constants
+
 menu_kb = types.ReplyKeyboardMarkup(
     resize_keyboard=True,
     keyboard=[
         [
-            types.KeyboardButton(text="Create a booking"),
-            types.KeyboardButton(text="Show the image with bookings"),
-            types.KeyboardButton(text="My bookings"),
-        ]
+            types.KeyboardButton(text=constants.create_booking_message),
+            types.KeyboardButton(text=constants.my_bookings_message),
+        ],
+        [
+            types.KeyboardButton(text=constants.image_schedule_message),
+        ],
     ],
+)
+
+help_kb = types.InlineKeyboardMarkup(
+    inline_keyboard=[
+        [
+            types.InlineKeyboardButton(text="Instructions", url=constants.instructions_url),
+            types.InlineKeyboardButton(text="Location", url=constants.how_to_get_url),
+        ],
+        [
+            types.InlineKeyboardButton(text="Telegram chat", url=constants.tg_chat_url),
+        ],
+    ]
 )

--- a/src/bot/routers/booking/create_booking_routes.py
+++ b/src/bot/routers/booking/create_booking_routes.py
@@ -9,6 +9,7 @@ from aiogram_dialog import Dialog, DialogManager, Window, StartMode
 from aiogram_dialog.widgets.kbd import Back, Button, Group, Cancel, Row
 from aiogram_dialog.widgets.text import Const, Format
 
+from src.bot import constants
 from src.bot.api import api_client
 from src.bot.routers.booking import router
 from src.bot.routers.booking.states import CreateBookingStates
@@ -17,7 +18,7 @@ from src.bot.routers.booking.widgets.time_range import TimeRangeWidget
 
 
 @router.message(any_state, Command("create_booking"))
-@router.message(any_state, F.text == "Create a booking")
+@router.message(any_state, F.text == constants.create_booking_message)
 async def start_booking(_message: Message, dialog_manager: DialogManager):
     await dialog_manager.start(
         CreateBookingStates.choose_date,

--- a/src/bot/routers/booking/my_bookings_routes.py
+++ b/src/bot/routers/booking/my_bookings_routes.py
@@ -5,13 +5,14 @@ from aiogram.filters import Command
 from aiogram.fsm.state import any_state
 from aiogram.types import Message
 
+from src.bot import constants
 from src.bot.api import api_client
 from src.bot.routers.booking import router
 from src.bot.routers.booking.callback_data import MyBookingsCallbackData
 
 
 @router.message(any_state, Command("my_bookings"))
-@router.message(any_state, F.text == "My bookings")
+@router.message(any_state, F.text == constants.my_bookings_message)
 async def show_my_bookings(message: Message):
     bookings = await api_client.get_user_bookings(message.from_user.id)
     # only future bookings

--- a/src/bot/routers/registration.py
+++ b/src/bot/routers/registration.py
@@ -7,9 +7,9 @@ from aiogram.fsm.state import StatesGroup, State
 from aiogram.fsm.state import any_state
 from aiogram.types import Message, LoginUrl
 
-from src.bot.constants import rules_confirmation_message, instructions_url, how_to_get_url, tg_chat_url
+from src.bot.constants import rules_confirmation_message
 from src.bot.filters import RegisteredUserFilter
-from src.bot.menu import menu_kb
+from src.bot.menu import menu_kb, help_kb
 from src.config import settings
 
 router = Router(name="registration")
@@ -101,19 +101,9 @@ async def confirm_rules(message: Message, state: FSMContext):
 
         await message.answer(text, reply_markup=menu_kb, parse_mode="HTML")
 
-        keyboard = types.InlineKeyboardMarkup(
-            inline_keyboard=[
-                [
-                    types.InlineKeyboardButton(text="Instructions", url=instructions_url),
-                    types.InlineKeyboardButton(text="Location", url=how_to_get_url),
-                    types.InlineKeyboardButton(text="Telegram chat", url=tg_chat_url),
-                ]
-            ]
-        )
-
         await message.answer(
             "If you have any questions, you can ask them in the chat or read the instructions.",
-            reply_markup=keyboard,
+            reply_markup=help_kb,
         )
 
         await state.clear()

--- a/src/bot/routers/schedule.py
+++ b/src/bot/routers/schedule.py
@@ -8,6 +8,7 @@ from aiogram.filters.callback_data import CallbackData
 from aiogram.fsm.state import any_state
 from aiogram.types import BufferedInputFile
 
+from src.bot import constants
 from src.bot.api import api_client
 from src.bot.logging_ import logger
 
@@ -31,7 +32,7 @@ image_schedule_kb = types.InlineKeyboardMarkup(
 
 
 @router.message(any_state, Command("image_schedule"))
-@router.message(any_state, F.text == "Show the image with bookings")
+@router.message(any_state, F.text == constants.image_schedule_message)
 async def get_image_schedule(message: types.Message):
     start_of_week = get_start_of_week()
     image_bytes = await api_client.get_image_schedule(start_of_week)

--- a/src/bot/routers/start_help_menu.py
+++ b/src/bot/routers/start_help_menu.py
@@ -2,7 +2,7 @@ from aiogram import Router
 from aiogram import types
 from aiogram.filters import Command, CommandStart
 
-from src.bot.constants import instructions_url, how_to_get_url, tg_chat_url
+from src.bot.menu import help_kb
 
 router = Router(name="start_help_menu")
 
@@ -16,18 +16,9 @@ async def start(message: types.Message):
 
 @router.message(Command("help"))
 async def help_handler(message: types.Message):
-    keyboard = types.InlineKeyboardMarkup(
-        inline_keyboard=[
-            [
-                types.InlineKeyboardButton(text="Instructions", url=instructions_url),
-                types.InlineKeyboardButton(text="Location", url=how_to_get_url),
-                types.InlineKeyboardButton(text="Telegram chat", url=tg_chat_url),
-            ]
-        ]
-    )
-
     await message.answer(
-        "If you have any questions, you can ask them in the chat or read the instructions.", reply_markup=keyboard
+        "If you have any questions, you can ask them in the chat or read the instructions.",
+        reply_markup=help_kb,
     )
 
 


### PR DESCRIPTION
### Description of changes

- Text for reply keyboard buttons extracted to constants to avoid mismatch with update handlers.
- Duplicated code of the inline keyboard with help info extracted to a constant.
- Buttons for these keyboards are divided onto 2 rows to make text fit.

Closes #41, closes #44.