### PR TITLE
feat: render schedule from svg

### DIFF
--- a/api.Dockerfile
+++ b/api.Dockerfile
@@ -46,6 +46,14 @@ RUN poetry install --no-interaction
 # Production stage. Copy only runtime deps that were installed in the Builder stage.
 FROM base AS production
 
+# Dependencies for rendering SVG (cairosvg and fonts)
+RUN apt-get update \
+    && apt-get install --no-install-recommends -y \
+        fonts-roboto \
+        libcairo2-dev \
+        libffi-dev \
+    && rm -rf /var/lib/apt/lists/*
+
 COPY --from=builder $VENV_PATH $VENV_PATH
 
 COPY --chmod=755 ./deploy/docker-entrypoint.sh ./deploy/docker-entrypoint-alembic.sh /

--- a/poetry.lock
+++ b/poetry.lock
@@ -369,6 +369,47 @@ files = [
 ]
 
 [[package]]
+name = "cairocffi"
+version = "1.7.1"
+description = "cffi-based cairo bindings for Python"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "cairocffi-1.7.1-py3-none-any.whl", hash = "sha256:9803a0e11f6c962f3b0ae2ec8ba6ae45e957a146a004697a1ac1bbf16b073b3f"},
+    {file = "cairocffi-1.7.1.tar.gz", hash = "sha256:2e48ee864884ec4a3a34bfa8c9ab9999f688286eb714a15a43ec9d068c36557b"},
+]
+
+[package.dependencies]
+cffi = ">=1.1.0"
+
+[package.extras]
+doc = ["sphinx", "sphinx_rtd_theme"]
+test = ["numpy", "pikepdf", "pytest", "ruff"]
+xcb = ["xcffib (>=1.4.0)"]
+
+[[package]]
+name = "cairosvg"
+version = "2.7.1"
+description = "A Simple SVG Converter based on Cairo"
+optional = false
+python-versions = ">=3.5"
+files = [
+    {file = "CairoSVG-2.7.1-py3-none-any.whl", hash = "sha256:8a5222d4e6c3f86f1f7046b63246877a63b49923a1cd202184c3a634ef546b3b"},
+    {file = "CairoSVG-2.7.1.tar.gz", hash = "sha256:432531d72347291b9a9ebfb6777026b607563fd8719c46ee742db0aef7271ba0"},
+]
+
+[package.dependencies]
+cairocffi = "*"
+cssselect2 = "*"
+defusedxml = "*"
+pillow = "*"
+tinycss2 = "*"
+
+[package.extras]
+doc = ["sphinx", "sphinx-rtd-theme"]
+test = ["flake8", "isort", "pytest"]
+
+[[package]]
 name = "certifi"
 version = "2024.8.30"
 description = "Python package for providing Mozilla's CA Bundle."
@@ -559,6 +600,36 @@ sdist = ["build"]
 ssh = ["bcrypt (>=3.1.5)"]
 test = ["certifi", "cryptography-vectors (==43.0.3)", "pretend", "pytest (>=6.2.0)", "pytest-benchmark", "pytest-cov", "pytest-xdist"]
 test-randomorder = ["pytest-randomly"]
+
+[[package]]
+name = "cssselect2"
+version = "0.7.0"
+description = "CSS selectors for Python ElementTree"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "cssselect2-0.7.0-py3-none-any.whl", hash = "sha256:fd23a65bfd444595913f02fc71f6b286c29261e354c41d722ca7a261a49b5969"},
+    {file = "cssselect2-0.7.0.tar.gz", hash = "sha256:1ccd984dab89fc68955043aca4e1b03e0cf29cad9880f6e28e3ba7a74b14aa5a"},
+]
+
+[package.dependencies]
+tinycss2 = "*"
+webencodings = "*"
+
+[package.extras]
+doc = ["sphinx", "sphinx_rtd_theme"]
+test = ["flake8", "isort", "pytest"]
+
+[[package]]
+name = "defusedxml"
+version = "0.7.1"
+description = "XML bomb protection for Python stdlib modules"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+files = [
+    {file = "defusedxml-0.7.1-py2.py3-none-any.whl", hash = "sha256:a352e7e428770286cc899e2542b6cdaedb2b4953ff269a210103ec58f6198a61"},
+    {file = "defusedxml-0.7.1.tar.gz", hash = "sha256:1bb3032db185915b62d7c6209c5a8792be6a32ab2fedacc84e01b52c51aa3e69"},
+]
 
 [[package]]
 name = "distlib"
@@ -2012,6 +2083,24 @@ anyio = ">=3.4.0,<5"
 full = ["httpx (>=0.22.0)", "itsdangerous", "jinja2", "python-multipart (>=0.0.7)", "pyyaml"]
 
 [[package]]
+name = "tinycss2"
+version = "1.4.0"
+description = "A tiny CSS parser"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "tinycss2-1.4.0-py3-none-any.whl", hash = "sha256:3a49cf47b7675da0b15d0c6e1df8df4ebd96e9394bb905a5775adb0d884c5289"},
+    {file = "tinycss2-1.4.0.tar.gz", hash = "sha256:10c0972f6fc0fbee87c3edb76549357415e94548c1ae10ebccdea16fb404a9b7"},
+]
+
+[package.dependencies]
+webencodings = ">=0.4"
+
+[package.extras]
+doc = ["sphinx", "sphinx_rtd_theme"]
+test = ["pytest", "ruff"]
+
+[[package]]
 name = "typing-extensions"
 version = "4.12.2"
 description = "Backported and Experimental Type Hints for Python 3.8+"
@@ -2070,6 +2159,17 @@ platformdirs = ">=3.9.1,<5"
 [package.extras]
 docs = ["furo (>=2023.7.26)", "proselint (>=0.13)", "sphinx (>=7.1.2,!=7.3)", "sphinx-argparse (>=0.4)", "sphinxcontrib-towncrier (>=0.2.1a0)", "towncrier (>=23.6)"]
 test = ["covdefaults (>=2.3)", "coverage (>=7.2.7)", "coverage-enable-subprocess (>=1)", "flaky (>=3.7)", "packaging (>=23.1)", "pytest (>=7.4)", "pytest-env (>=0.8.2)", "pytest-freezer (>=0.4.8)", "pytest-mock (>=3.11.1)", "pytest-randomly (>=3.12)", "pytest-timeout (>=2.1)", "setuptools (>=68)", "time-machine (>=2.10)"]
+
+[[package]]
+name = "webencodings"
+version = "0.5.1"
+description = "Character encoding aliases for legacy web content"
+optional = false
+python-versions = "*"
+files = [
+    {file = "webencodings-0.5.1-py2.py3-none-any.whl", hash = "sha256:a0af1213f3c2226497a97e2b3aa01a7e4bee4f403f95be16fc9acd2947514a78"},
+    {file = "webencodings-0.5.1.tar.gz", hash = "sha256:b36a1c245f2d304965eb4e0a82848379241dc04b865afcc4aab16748587e1923"},
+]
 
 [[package]]
 name = "yarl"
@@ -2170,4 +2270,4 @@ propcache = ">=0.2.0"
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.12"
-content-hash = "1c6d460e2e778759f7748589c9a7cbc5f2c419431264bd027af6b6f0f08d6dd9"
+content-hash = "089bd10e863a7bc7de0597a794a7d10e94d2f28b6ec53f0ade7be0d7bdb25d48"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ redis = "^5.1.0"
 ruff = "^0.7.4"
 sqlalchemy = "^2.0.23"
 uvicorn = "^0.32.1"
+cairosvg = "^2.7.1"
 
 [tool.ruff]
 line-length = 120

--- a/src/api/bookings/routes.py
+++ b/src/api/bookings/routes.py
@@ -82,8 +82,9 @@ async def get_my_bookings(verified: VerifiedDepWithUserID) -> list[ViewBooking]:
 )
 async def form_schedule(
     start_of_week: datetime.date | None = Query(default_factory=_get_start_of_week, example=_get_start_of_week()),
+    from_user_id: int | None = None,
 ) -> Response:
-    image_bytes = await booking_repository.form_schedule(start_of_week)
+    image_bytes = await booking_repository.form_schedule(start_of_week, from_user_id)
     return Response(content=image_bytes, media_type="image/png")
 
 

--- a/src/bot/api.py
+++ b/src/bot/api.py
@@ -119,8 +119,8 @@ class InNoHassleMusicRoomAPI:
             response = await client.delete(f"/bookings/{booking_id}")
             return True if response.status_code == 200 else False
 
-    async def get_image_schedule(self, start_of_week: datetime.date) -> bytes | None:
-        params = {"start_of_week": start_of_week.isoformat()}
+    async def get_image_schedule(self, start_of_week: datetime.date, from_user_id: int) -> bytes | None:
+        params = {"start_of_week": start_of_week.isoformat(), "from_user_id": from_user_id}
         async with self._create_client() as client:
             response = await client.get("/bookings/form_schedule", params=params)
             if response.status_code == 200:

--- a/src/bot/routers/booking/widgets/time_range.py
+++ b/src/bot/routers/booking/widgets/time_range.py
@@ -165,6 +165,11 @@ class TimeRangeWidget(Keyboard):
                         keyboard_builer.button(text="🔴", url=f"https://t.me/{booked_by_alias}")
                 elif available and not blocked:
                     keyboard_builer.button(text=time_text, callback_data=time_callback_data)
+                else:
+                    keyboard_builer.button(
+                        text=" ",
+                        callback_data=self._item_callback_data("None"),
+                    )
             else:
                 keyboard_builer.button(
                     text=" ",

--- a/src/bot/routers/schedule.py
+++ b/src/bot/routers/schedule.py
@@ -40,7 +40,7 @@ def get_image_schedule_kb() -> types.InlineKeyboardMarkup:
 )
 async def get_image_schedule(message: types.Message):
     start_of_week = get_start_of_week()
-    image_bytes = await api_client.get_image_schedule(start_of_week)
+    image_bytes = await api_client.get_image_schedule(start_of_week, message.from_user.id)
     photo = BufferedInputFile(image_bytes, "schedule.png")
     await message.answer(_("Sending image for the current week..."))
     await message.answer_photo(photo=photo)
@@ -70,7 +70,7 @@ async def get_image_schedule_for_current_week(callback: types.CallbackQuery):
     choice = callback.data
     chat_id = callback.from_user.id
     start_of_week = get_start_of_week(choice == "schedule:current_week")
-    image_bytes = await api_client.get_image_schedule(start_of_week)
+    image_bytes = await api_client.get_image_schedule(start_of_week, callback.from_user.id)
     photo = BufferedInputFile(image_bytes, "schedule.png")
     if choice == "schedule:current_week":
         await callback.message.answer(_("Sending image for the current week..."))

--- a/src/repositories/bookings/repository.py
+++ b/src/repositories/bookings/repository.py
@@ -4,13 +4,15 @@ import datetime
 import io
 from datetime import datetime as datetime_datetime
 from datetime import timedelta
+from pathlib import Path
 from typing import Optional, Self
 
-from PIL import Image, ImageDraw, ImageFont
+from cairosvg import svg2png
 from sqlalchemy import and_, between, delete, insert, not_, or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from src.exceptions import NoSuchBooking
+from src.repositories.users.repository import user_repository
 from src.schemas import CreateBooking, ViewBooking, ViewUser
 from src.storage.sql import AbstractSQLAlchemyStorage
 from src.storage.sql.models import Booking, User
@@ -84,139 +86,168 @@ class SqlBookingRepository:
             obj = await session.scalar(query)
             return ViewUser.model_validate(obj)
 
-    async def draw_week_numbers(self, draw: ImageDraw, current_week: bool):
-        fontSimple = ImageFont.truetype("src/repositories/bookings/open_sans.ttf", size=14)
-        lightBlack = (48, 54, 59)
-
-        weekdays_numbers, wide = await get_week_numbers(current_week)
-
-        x_coord = 130
-        y_coord = 30
-        week_days = 7
-        offset = 175 if wide else 176
-
-        draw.text(
-            (x_coord, y_coord),
-            text=f"{weekdays_numbers[0]}",
-            fill=lightBlack,
-            font=fontSimple,
-        )
-
-        for i in range(1, week_days):
-            draw.text(
-                (x_coord + offset * i, y_coord),
-                text=f"{weekdays_numbers[i]}",
-                fill=lightBlack,
-                font=fontSimple,
-            )
-
-    async def draw_month_and_year(self, draw: ImageDraw, current_week: bool):
-        fontSimple = ImageFont.truetype("src/repositories/bookings/open_sans.ttf", size=14)
-        lightBlack = (48, 54, 59)
-
-        offset = 7 if not current_week else 0
-        current_datetime = datetime.datetime.now() + datetime.timedelta(offset)
-        current_year = current_datetime.year
-        current_month = current_datetime.strftime("%b")
-        draw.text(
-            (12, 12),
-            text=f"{current_month} {current_year}",
-            fill=lightBlack,
-            font=fontSimple,
-        )
-
     async def is_start_of_week(self, start_of_week: datetime.date):
         today = datetime.datetime.now()
 
         return (today - timedelta(days=today.weekday())).date() == start_of_week
 
-    async def form_schedule(self, start_of_week: datetime.date) -> bytes:
-        xbase = 48  # origin for x
-        ybase = 73  # origin for y
-        xsize = round(175.5)  # length of the rect by x-axis
-        ysize = 32  # length of the rect by x-axis
+    async def form_schedule(self, start_of_week: datetime.date, from_user_id: int) -> bytes:
+        with open(Path(__file__).parent / "resources/Plain.svg", encoding="utf-8") as file:
+            svg_string = file.read()
 
-        # Create a new image using PIL
-        image = Image.open("src/repositories/bookings/schedule.jpg")
-        draw = ImageDraw.Draw(image)
+        weekdays_numbers, wide = await get_week_numbers(await self.is_start_of_week(start_of_week))
+        today = datetime.datetime.today().day
 
-        lightGray = (211, 211, 211)
-        lightBlack = (48, 54, 59)
-        red = (255, 0, 0)
+        for i, (number, identifier) in enumerate(
+            zip(weekdays_numbers, "monnum tuenum wednum thunum frinum satnum sunnum".split())
+        ):
+            text = f"""
+            <tspan xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+            sodipodi:role="line" id="tspan40"
+            x="{266.9544915 + (0 if i == 0 else 126.16007 if i == 1 else 122.16095 * (i - 1) + 126.16007)}"
+            y="{66}" style="font-style:normal;
+            font-variant:normal;font-weight:bold;font-stretch:normal;font-size:20px;font-family:Roboto;
+            -inkscape-font-specification:'Roboto Bold';text-align:start;text-anchor:middle;fill:#000000;
+            fill-opacity:1;stroke:none">{identifier[:3].capitalize()} {number}</tspan>
+            """
 
-        fontSimple = ImageFont.truetype("src/repositories/bookings/open_sans.ttf", size=14)
+            end = svg_string.rfind("/>") + 2
+            svg_string = svg_string[:end] + text + svg_string[end:]
+
+            if today == number:
+                end = svg_string.index(identifier[:3])
+                end = svg_string.rfind('"opacity:', 0, end) + 8
+                svg_string = f"{svg_string[:end]}1{svg_string[end + 1:]}"
+
+        character_widths = {
+            "a": 11.2,
+            "b": 11.2,
+            "c": 10.4,
+            "d": 11.13,
+            "e": 11.2,
+            "f": 8,
+            "g": 11.13,
+            "h": 11.13,
+            "i": 4.45,
+            "j": 6.05,
+            "k": 10.4,
+            "l": 4.45,
+            "m": 16.66,
+            "n": 11.13,
+            "o": 11.2,
+            "p": 11.2,
+            "q": 11.13,
+            "r": 7.2,
+            "s": 10,
+            "t": 6.4,
+            "u": 11.13,
+            "v": 10.4,
+            "w": 16,
+            "x": 11.2,
+            "y": 10.4,
+            "z": 10.4,
+            "A": 14.4,
+            "B": 13.35,
+            "C": 14.45,
+            "D": 14.45,
+            "E": 13.45,
+            "F": 12.23,
+            "G": 15.56,
+            "H": 14.45,
+            "I": 5.56,
+            "J": 10,
+            "K": 13.6,
+            "L": 11.2,
+            "M": 16.66,
+            "N": 14.45,
+            "O": 15.56,
+            "P": 13.35,
+            "Q": 15.56,
+            "R": 14.45,
+            "S": 13.35,
+            "T": 12.8,
+            "U": 14.45,
+            "V": 14.4,
+            "W": 19.2,
+            "X": 14.4,
+            "Y": 14.4,
+            "Z": 12.23,
+            "0": 11.13,
+            "1": 11.13,
+            "2": 11.13,
+            "3": 11.2,
+            "4": 11.13,
+            "5": 11.2,
+            "6": 11.2,
+            "7": 11.2,
+            "8": 11.2,
+            "9": 11.2,
+            "_": 12.8,
+        }
 
         bookings = await self.get_bookings_for_week(start_of_week)
+        current_hour = datetime.datetime.now().hour
+        cell_size = [124.161, 83.451]
+        middle_offset = 17.739
         for booking in bookings:
-            ylength = count_duration(booking.time_start, booking.time_end)
-
-            cell_canvas = Image.new("RGB", (xsize, int(ysize * ylength)), "white")
-            cell_canvas_painter = ImageDraw.Draw(cell_canvas)
+            if booking.time_start.hour == current_hour:
+                try:
+                    end = svg_string.index(f"i{current_hour}")
+                    end = svg_string.rfind('"opacity:', 0, end) + 8
+                    svg_string = f"{svg_string[:end]}1{svg_string[end + 1:]}"
+                except ValueError:
+                    pass
+            duration = count_duration(booking.time_start, booking.time_end)
             day = booking.time_start.weekday()
+            coordinates = [
+                (cell_size[0] - 2) * day,
+                (cell_size[1] - 2) * ((booking.time_start.hour - 7) + booking.time_start.minute / 60),
+            ]
 
-            x0 = xbase + xsize * day
-            y0 = ybase + int(ysize * ((booking.time_start.hour - 7) + (booking.time_start.minute / 60.0)))
+            user = await user_repository.get_user(booking.user_id)
 
-            cell_canvas_painter.rounded_rectangle(
-                (0, 0, cell_canvas.width - 1, cell_canvas.height - 1), 2, fill=lightGray, outline=lightBlack, width=2
-            )
-            user = await self.get_user(booking.user_id)
-            caption = user.alias
-
-            # noinspection SqlAlchemyUnsafeQuery
-            cell_canvas_painter.text(
-                (8, cell_canvas.height / 2 - 9),
-                text=caption,
-                fill=lightBlack,
-                font=fontSimple,
-            )
-
-            time_canvas = Image.new("RGBA", (xsize, ysize), (0, 0, 0, 0))
-            time_canvas_painter = ImageDraw.Draw(time_canvas)
-
-            time_canvas_painter.text(
-                (9, 0),
-                text=f"{booking.time_start.strftime('%H:%M')}-{booking.time_end.strftime('%H:%M')}",
-                fill=lightBlack,
-                font=fontSimple,
-            )
-
-            time_canvas_rect = time_canvas.getbbox()
-            cell_canvas_painter.rectangle(
-                (
-                    cell_canvas.width - time_canvas_rect[2] + time_canvas_rect[0] - 14,
-                    2,
-                    cell_canvas.width - 3,
-                    cell_canvas.height - 3,
-                ),
-                lightGray,
-            )
-            cell_canvas.paste(
-                time_canvas,
-                (cell_canvas.width - time_canvas_rect[2] + time_canvas_rect[0] - 17, cell_canvas.height // 2 - 9),
-                time_canvas,
-            )
-
-            image.paste(cell_canvas, (int(x0), y0))
-
-        today = datetime.date.today()
-        weekday = today.weekday()
-
-        current = datetime.datetime.now()
-        current_week = False
-        if start_of_week <= current.date() <= start_of_week + timedelta(days=6):
-            current_week = True
-
-        # Drawing red line
-        if 6 < current.hour < 23 and current_week:
-            now_x0 = xbase + xsize * weekday
-            now_y0 = ybase + int(ysize * ((current.hour - 7) + (current.minute / 60)))
-            draw.rounded_rectangle((now_x0, now_y0, now_x0 + xsize, now_y0 + 2), 2, fill=red)
-
-        await self.draw_week_numbers(draw, await self.is_start_of_week(start_of_week))
-        await self.draw_month_and_year(draw, current_week)
+            symbol = f"""<svg x="{coordinates[0]}" y="{coordinates[1]}">
+            <rect style="opacity:1;
+            fill:{"#e5e2e5" if user.telegram_id == from_user_id else "none"};
+            fill-opacity:1;stroke:#e5e2e5;stroke-width:2;
+            stroke-linecap:round;stroke-linejoin:round;
+            stroke-opacity:1" id="rect119"
+            width="122.16101" height="{duration * (cell_size[1] - 2)}"
+            x="207.87349" y="119.77097"
+            rx="0" ry="0"/></svg>"""
+            perceptual_text_y_offset = 5
+            perceptual_text_x_offset = -33.5
+            text_time_symbol = f"""
+            <tspan id="tspan89" x="{268.955 + coordinates[0] + perceptual_text_x_offset}"
+            y="{119.77097 + coordinates[1] + duration * (cell_size[1] - 2) / 2 + perceptual_text_y_offset}"
+            style="font-style:normal;font-variant:normal;font-weight:normal;
+            font-stretch:normal;font-family:'Roboto';text-align:start;text-anchor:middle;
+            -inkscape-font-specification:'Roboto';
+            fill:#000000;fill-opacity:1;stroke:none;font-size:20px">
+            {booking.time_start.strftime('%H:%M')}-{booking.time_end.strftime('%H:%M')}</tspan>"""
+            text_alias_symbol = ""
+            if duration > 0.5:
+                max_width = 112
+                alias = ""
+                current_width = 0
+                for elem in user.alias:
+                    if (current_width := current_width + character_widths[elem]) <= max_width:
+                        alias += elem
+                    else:
+                        break
+                text_alias_symbol = f"""
+            <tspan id="tspan89" x="{268.955 + coordinates[0] + perceptual_text_x_offset}"
+            y="{119.77097 + coordinates[1] + duration * (cell_size[1] - 2) / 2
+                + perceptual_text_y_offset * 2 + middle_offset}"
+            style="font-style:normal;font-variant:normal;font-weight:normal;
+            font-stretch:normal;font-family:'Roboto';text-anchor:middle;-inkscape-font-specification:'Roboto';
+            fill:#000000;fill-opacity:1;stroke:none;font-size:20px">
+            {alias}</tspan>"""
+            end = svg_string.index(">", svg_string.index(">") + 1) + 1
+            svg_string = f"{svg_string[:end]}{symbol}{text_alias_symbol}{text_time_symbol}{svg_string[end:]}"
+        open("TEST.txt", "w").write(svg_string)
         image_stream = io.BytesIO()
-        image.save(image_stream, format="png")
+        svg2png(bytestring=svg_string, write_to=image_stream, scale=2)
         val = image_stream.getvalue()
         image_stream.close()
         return val

--- a/src/repositories/bookings/resources/Plain.svg
+++ b/src/repositories/bookings/resources/Plain.svg
@@ -1,0 +1,702 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+
+<svg
+   width="1080"
+   height="1520"
+   viewBox="0 0 1080 1520"
+   version="1.1"
+   id="svg1"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <rect
+     style="opacity:0;fill:#e5e2e5;fill-opacity:1;stroke:#e5e2e5;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1"
+     id="i7"
+     width="174.87401"
+     height="63.649006"
+     x="16.99988"
+     y="128.6727"
+     ry="20.000004"
+     rx="20" />
+  <rect
+     style="opacity:0;fill:#e5e2e5;fill-opacity:1;stroke:#e5e2e5;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1"
+     id="i8"
+     width="174.87401"
+     height="63.649006"
+     x="16.99988"
+     y="210.12421"
+     ry="20.000004"
+     rx="20" />
+  <rect
+     style="opacity:0;fill:#e5e2e5;fill-opacity:1;stroke:#e5e2e5;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1"
+     id="i9"
+     width="174.87401"
+     height="63.649006"
+     x="16.99988"
+     y="291.57602"
+     ry="20.000004"
+     rx="20" />
+  <rect
+     style="opacity:0;fill:#e5e2e5;fill-opacity:1;stroke:#e5e2e5;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1"
+     id="i10"
+     width="174.87401"
+     height="63.649006"
+     x="16.99988"
+     y="373.02783"
+     ry="20.000004"
+     rx="20" />
+  <rect
+     style="opacity:0;fill:#e5e2e5;fill-opacity:1;stroke:#e5e2e5;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1"
+     id="i11"
+     width="174.87401"
+     height="63.649006"
+     x="16.99988"
+     y="454.47961"
+     ry="20.000004"
+     rx="20" />
+  <rect
+     style="opacity:0;fill:#e5e2e5;fill-opacity:1;stroke:#e5e2e5;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1"
+     id="i12"
+     width="174.87401"
+     height="63.649006"
+     x="16.99988"
+     y="535.93146"
+     ry="20.000004"
+     rx="20" />
+  <rect
+     style="opacity:0;fill:#e5e2e5;fill-opacity:1;stroke:#e5e2e5;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1"
+     id="i13"
+     width="174.87401"
+     height="63.649006"
+     x="16.99988"
+     y="617.38324"
+     ry="20.000004"
+     rx="20" />
+  <rect
+     style="opacity:0;fill:#e5e2e5;fill-opacity:1;stroke:#e5e2e5;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1"
+     id="i14"
+     width="174.87401"
+     height="63.649006"
+     x="16.99988"
+     y="698.83502"
+     ry="20.000004"
+     rx="20" />
+  <rect
+     style="opacity:0;fill:#e5e2e5;fill-opacity:1;stroke:#e5e2e5;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1"
+     id="i15"
+     width="174.87401"
+     height="63.649006"
+     x="16.99988"
+     y="780.28687"
+     ry="20.000004"
+     rx="20" />
+  <rect
+     style="opacity:0;fill:#e5e2e5;fill-opacity:1;stroke:#e5e2e5;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1"
+     id="i16"
+     width="174.87401"
+     height="63.649006"
+     x="16.99988"
+     y="861.73865"
+     ry="20.000004"
+     rx="20" />
+  <rect
+     style="opacity:0;fill:#e5e2e5;fill-opacity:1;stroke:#e5e2e5;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1"
+     id="i17"
+     width="174.87401"
+     height="63.649006"
+     x="16.99988"
+     y="943.19049"
+     ry="20.000004"
+     rx="20" />
+  <rect
+     style="opacity:0;fill:#e5e2e5;fill-opacity:1;stroke:#e5e2e5;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1"
+     id="i18"
+     width="174.87401"
+     height="63.649006"
+     x="16.99988"
+     y="1024.6423"
+     ry="20.000004"
+     rx="20" />
+  <rect
+     style="opacity:0;fill:#e5e2e5;fill-opacity:1;stroke:#e5e2e5;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1"
+     id="i19"
+     width="174.87401"
+     height="63.649006"
+     x="16.99988"
+     y="1106.0941"
+     ry="20.000004"
+     rx="20" />
+  <rect
+     style="opacity:0;fill:#e5e2e5;fill-opacity:1;stroke:#e5e2e5;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1"
+     id="i20"
+     width="174.87401"
+     height="63.649006"
+     x="16.99988"
+     y="1187.5459"
+     ry="20.000004"
+     rx="20" />
+  <rect
+     style="opacity:0;fill:#e5e2e5;fill-opacity:1;stroke:#e5e2e5;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1"
+     id="i21"
+     width="174.87401"
+     height="63.649006"
+     x="16.99988"
+     y="1268.9977"
+     ry="20.000004"
+     rx="20" />
+  <rect
+     style="opacity:0;fill:#e5e2e5;fill-opacity:1;stroke:#e5e2e5;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1"
+     id="i22"
+     width="174.87401"
+     height="63.649006"
+     x="16.99988"
+     y="1350.4495"
+     ry="20.000004"
+     rx="20" />
+  <rect
+     style="opacity:0;fill:#e5e2e5;fill-opacity:1;stroke:#e5e2e5;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1"
+     id="i23"
+     width="174.87401"
+     height="63.649006"
+     x="16.99988"
+     y="1431.9014"
+     ry="20.000004"
+     rx="20" />
+  <rect
+     style="opacity:0;fill:#e5e2e5;fill-opacity:1;stroke:#e5e2e5;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1"
+     id="mon"
+     width="92.161003"
+     height="63.649006"
+     x="220.87399"
+     y="29.049921"
+     ry="20.000004"
+     rx="20" />
+  <rect
+     style="opacity:0;fill:#e5e2e5;fill-opacity:1;stroke:#e5e2e5;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1"
+     id="tue"
+     width="88.161003"
+     height="63.649006"
+     x="347.03406"
+     y="29.049921"
+     ry="20.000004"
+     rx="19.999998" />
+  <rect
+     style="opacity:0;fill:#e5e2e5;fill-opacity:1;stroke:#e5e2e5;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1"
+     id="wed"
+     width="88.161003"
+     height="63.649006"
+     x="469.19501"
+     y="29.049921"
+     ry="20.000004"
+     rx="19.999998" />
+  <rect
+     style="opacity:0;fill:#e5e2e5;fill-opacity:1;stroke:#e5e2e5;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1"
+     id="thu"
+     width="88.161003"
+     height="63.649006"
+     x="591.35699"
+     y="29.049921"
+     ry="20.000004"
+     rx="19.999998" />
+  <rect
+     style="opacity:0;fill:#e5e2e5;fill-opacity:1;stroke:#e5e2e5;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1"
+     id="fri"
+     width="88.161003"
+     height="63.649006"
+     x="713.51794"
+     y="29.049921"
+     ry="20.000004"
+     rx="19.999998" />
+  <rect
+     style="opacity:0;fill:#e5e2e5;fill-opacity:1;stroke:#e5e2e5;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1"
+     id="sat"
+     width="88.161003"
+     height="63.649006"
+     x="835.67902"
+     y="29.049921"
+     ry="20.000004"
+     rx="19.999998" />
+  <rect
+     style="opacity:0;fill:#e5e2e5;fill-opacity:1;stroke:#e5e2e5;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1"
+     id="sun"
+     width="88.161003"
+     height="63.649006"
+     x="957.83997"
+     y="29.049921"
+     ry="20.000004"
+     rx="19.999998" />
+  <rect
+     style="display:inline;fill:none;fill-opacity:1;stroke:#e5e2e5;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1"
+     id="rect1"
+     width="186.87352"
+     height="83.770882"
+     x="17"
+     y="17"
+     ry="20"
+     rx="20" />
+  <rect
+     style="display:inline;fill:none;stroke:#e5e2e5;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1"
+     id="table"
+     width="855.12701"
+     height="1385.678"
+     x="207.8735"
+     y="119.77099"
+     ry="20.000006"
+     rx="20" />
+  <path
+     style="display:inline;fill:none;fill-opacity:1;stroke:#e5e2e5;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1"
+     d="M 330.03452,17 V 51.237036"
+     id="path4" />
+  <path
+     style="display:inline;fill:none;fill-opacity:1;stroke:#e5e2e5;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1"
+     d="M 452.19551,17 V 51.237036"
+     id="path5" />
+  <path
+     style="display:inline;fill:none;fill-opacity:1;stroke:#e5e2e5;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1"
+     d="M 574.35651,17 V 51.237036"
+     id="path6" />
+  <path
+     style="display:inline;fill:none;fill-opacity:1;stroke:#e5e2e5;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1"
+     d="M 696.51751,17 V 51.237036"
+     id="path7" />
+  <path
+     style="display:inline;fill:none;fill-opacity:1;stroke:#e5e2e5;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1"
+     d="M 940.8395,17 V 51.237036"
+     id="path9" />
+  <path
+     style="display:inline;fill:none;fill-opacity:1;stroke:#e5e2e5;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1"
+     d="M 818.67851,17 V 51.237036"
+     id="path10" />
+  <path
+     style="display:inline;fill:none;fill-opacity:1;stroke:#e5e2e5;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1"
+     d="M 51.23716,119.771 H 16.99988"
+     id="path11" />
+  <path
+     style="display:inline;fill:none;fill-opacity:1;stroke:#e5e2e5;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1"
+     d="M 51.236923,201.22281 H 16.99988"
+     id="path12" />
+  <path
+     style="display:inline;fill:none;fill-opacity:1;stroke:#e5e2e5;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1"
+     d="M 51.236923,1015.7409 H 16.99988"
+     id="path13" />
+  <path
+     style="display:inline;fill:none;fill-opacity:1;stroke:#e5e2e5;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1"
+     d="M 51.236923,1097.1927 H 16.99988"
+     id="path14" />
+  <path
+     style="display:inline;fill:none;fill-opacity:1;stroke:#e5e2e5;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1"
+     d="M 51.236923,1178.6445 H 16.99988"
+     id="path15" />
+  <path
+     style="display:inline;fill:none;fill-opacity:1;stroke:#e5e2e5;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1"
+     d="M 51.236923,1341.5481 H 16.99988"
+     id="path17" />
+  <path
+     style="display:inline;fill:none;fill-opacity:1;stroke:#e5e2e5;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1"
+     d="M 51.236923,1260.0963 H 16.99988"
+     id="path18" />
+  <path
+     style="display:inline;fill:none;fill-opacity:1;stroke:#e5e2e5;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1"
+     d="M 51.236923,282.67461 H 16.99988"
+     id="path19" />
+  <path
+     style="display:inline;fill:none;fill-opacity:1;stroke:#e5e2e5;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1"
+     d="M 51.236923,364.12642 H 16.99988"
+     id="path20" />
+  <path
+     style="display:inline;fill:none;fill-opacity:1;stroke:#e5e2e5;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1"
+     d="M 51.236923,445.57823 H 16.99988"
+     id="path21" />
+  <path
+     style="display:inline;fill:none;fill-opacity:1;stroke:#e5e2e5;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1"
+     d="M 51.236923,527.03003 H 16.99988"
+     id="path22" />
+  <path
+     style="display:inline;fill:none;fill-opacity:1;stroke:#e5e2e5;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1"
+     d="M 51.236923,608.48184 H 16.99988"
+     id="path23" />
+  <path
+     style="display:inline;fill:none;fill-opacity:1;stroke:#e5e2e5;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1"
+     d="M 51.236923,689.93364 H 16.99988"
+     id="path24" />
+  <path
+     style="display:inline;fill:none;fill-opacity:1;stroke:#e5e2e5;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1"
+     d="M 51.236923,771.38545 H 16.99988"
+     id="path25" />
+  <path
+     style="display:inline;fill:none;fill-opacity:1;stroke:#e5e2e5;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1"
+     d="M 51.236923,852.83726 H 16.99988"
+     id="path26" />
+  <path
+     style="display:inline;fill:none;fill-opacity:1;stroke:#e5e2e5;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1"
+     d="M 51.236923,934.28906 H 16.99988"
+     id="path27" />
+  <path
+     style="display:inline;fill:none;fill-opacity:1;stroke:#e5e2e5;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1"
+     d="M 51.236925,1423 H 16.99988"
+     id="path64" />
+  <text
+     xml:space="preserve"
+     style="font-weight:bold;font-size:26.6667px;line-height:1.1;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:end;text-anchor:end;fill:none;stroke:#b20938;stroke-width:4;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1"
+     x="40.311707"
+     y="169.97638"
+     id="text40"><tspan
+       id="tspan40"
+       x="40.311707"
+       y="169.97638"
+       style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:26.6667px;font-family:Roboto;-inkscape-font-specification:'Roboto Bold';text-align:start;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none">7</tspan></text>
+  <text
+     xml:space="preserve"
+     style="font-weight:bold;font-size:42.6667px;line-height:1.1;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:end;text-anchor:end;fill:none;stroke:#b20938;stroke-width:4;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1"
+     x="41.767368"
+     y="74.052116"
+     id="month"><tspan
+       id="tspan2"
+       x="41.767368"
+       y="74.052116"
+       style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:42.6667px;font-family:Roboto;-inkscape-font-specification:'Roboto Bold';text-align:start;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none">OCT</tspan></text>
+  <text
+     xml:space="preserve"
+     style="font-weight:bold;font-size:42.6667px;line-height:1.1;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:end;text-anchor:end;fill:none;stroke:#b20938;stroke-width:4;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1"
+     x="130.35611"
+     y="74.260452"
+     id="monthnum"><tspan
+       id="tspan6"
+       x="130.35611"
+       y="74.260452"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:42.6667px;font-family:Roboto;-inkscape-font-specification:Roboto;text-align:start;text-anchor:start;fill:#8f7e8a;fill-opacity:1;stroke:none">24</tspan></text>
+  <text
+     xml:space="preserve"
+     style="font-weight:bold;font-size:26.6667px;line-height:1.1;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:end;text-anchor:end;fill:none;stroke:#b20938;stroke-width:4;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1"
+     x="55.32505"
+     y="169.97638"
+     id="text103"><tspan
+       id="tspan103"
+       x="55.32505"
+       y="169.97638"
+       style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:26.6667px;font-family:Roboto;-inkscape-font-specification:'Roboto Bold';text-align:start;text-anchor:start;fill:#8f7e8a;fill-opacity:1;stroke:none">:00</tspan></text>
+  <text
+     xml:space="preserve"
+     style="font-weight:bold;font-size:26.6667px;line-height:1.1;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:end;text-anchor:end;fill:none;stroke:#b20938;stroke-width:4;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1"
+     x="40.311707"
+     y="251.42789"
+     id="text1"><tspan
+       id="tspan1"
+       x="40.311707"
+       y="251.42789"
+       style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:26.6667px;font-family:Roboto;-inkscape-font-specification:'Roboto Bold';text-align:start;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none">8</tspan></text>
+  <text
+     xml:space="preserve"
+     style="font-weight:bold;font-size:26.6667px;line-height:1.1;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:end;text-anchor:end;fill:none;stroke:#b20938;stroke-width:4;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1"
+     x="55.32505"
+     y="251.42789"
+     id="text3"><tspan
+       id="tspan3"
+       x="55.32505"
+       y="251.42789"
+       style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:26.6667px;font-family:Roboto;-inkscape-font-specification:'Roboto Bold';text-align:start;text-anchor:start;fill:#8f7e8a;fill-opacity:1;stroke:none">:00</tspan></text>
+  <text
+     xml:space="preserve"
+     style="font-weight:bold;font-size:26.6662px;line-height:1.1;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:end;text-anchor:end;fill:none;stroke:#b20938;stroke-width:4;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1"
+     x="40.311996"
+     y="332.91257"
+     id="text4"
+     transform="scale(0.99998141,1.0000186)"><tspan
+       id="tspan4"
+       x="40.311996"
+       y="332.91257"
+       style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:26.6662px;font-family:Roboto;-inkscape-font-specification:'Roboto Bold';text-align:start;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:4">9</tspan></text>
+  <text
+     xml:space="preserve"
+     style="font-weight:bold;font-size:26.6667px;line-height:1.1;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:end;text-anchor:end;fill:none;stroke:#b20938;stroke-width:4;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1"
+     x="55.32505"
+     y="332.8797"
+     id="text5"><tspan
+       id="tspan5"
+       x="55.32505"
+       y="332.8797"
+       style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:26.6667px;font-family:Roboto;-inkscape-font-specification:'Roboto Bold';text-align:start;text-anchor:start;fill:#8f7e8a;fill-opacity:1;stroke:none">:00</tspan></text>
+  <text
+     xml:space="preserve"
+     style="font-weight:bold;font-size:26.6667px;line-height:1.1;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:end;text-anchor:end;fill:none;stroke:#b20938;stroke-width:4;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1"
+     x="40.311707"
+     y="414.33151"
+     id="text7"><tspan
+       id="tspan7"
+       x="40.311707"
+       y="414.33151"
+       style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:26.6667px;font-family:Roboto;-inkscape-font-specification:'Roboto Bold';text-align:start;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none">10</tspan></text>
+  <text
+     xml:space="preserve"
+     style="font-weight:bold;font-size:26.6667px;line-height:1.1;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:end;text-anchor:end;fill:none;stroke:#b20938;stroke-width:4;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1"
+     x="71.514397"
+     y="414.33151"
+     id="text8"><tspan
+       id="tspan8"
+       x="71.514397"
+       y="414.33151"
+       style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:26.6667px;font-family:Roboto;-inkscape-font-specification:'Roboto Bold';text-align:start;text-anchor:start;fill:#8f7e8a;fill-opacity:1;stroke:none">:00</tspan></text>
+  <text
+     xml:space="preserve"
+     style="font-weight:bold;font-size:26.6667px;line-height:1.1;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:end;text-anchor:end;fill:none;stroke:#b20938;stroke-width:4;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1"
+     x="40.311707"
+     y="495.79633"
+     id="text35"><tspan
+       id="tspan35"
+       x="40.311707"
+       y="495.79633"
+       style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:26.6667px;font-family:Roboto;-inkscape-font-specification:'Roboto Bold';text-align:start;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none">11</tspan></text>
+  <text
+     xml:space="preserve"
+     style="font-weight:bold;font-size:26.6667px;line-height:1.1;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:end;text-anchor:end;fill:none;stroke:#b20938;stroke-width:4;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1"
+     x="71.514397"
+     y="495.78329"
+     id="text36"><tspan
+       id="tspan36"
+       x="71.514397"
+       y="495.78329"
+       style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:26.6667px;font-family:Roboto;-inkscape-font-specification:'Roboto Bold';text-align:start;text-anchor:start;fill:#8f7e8a;fill-opacity:1;stroke:none">:00</tspan></text>
+  <text
+     xml:space="preserve"
+     style="font-weight:bold;font-size:26.6667px;line-height:1.1;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:end;text-anchor:end;fill:none;stroke:#b20938;stroke-width:4;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1"
+     x="40.311707"
+     y="577.36536"
+     id="text37"><tspan
+       id="tspan37"
+       x="40.311707"
+       y="577.36536"
+       style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:26.6667px;font-family:Roboto;-inkscape-font-specification:'Roboto Bold';text-align:start;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none">12</tspan></text>
+  <text
+     xml:space="preserve"
+     style="font-weight:bold;font-size:26.6667px;line-height:1.1;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:end;text-anchor:end;fill:none;stroke:#b20938;stroke-width:4;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1"
+     x="71.514397"
+     y="577.23517"
+     id="text38"><tspan
+       id="tspan38"
+       x="71.514397"
+       y="577.23517"
+       style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:26.6667px;font-family:Roboto;-inkscape-font-specification:'Roboto Bold';text-align:start;text-anchor:start;fill:#8f7e8a;fill-opacity:1;stroke:none">:00</tspan></text>
+  <text
+     xml:space="preserve"
+     style="font-weight:bold;font-size:26.6667px;line-height:1.1;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:end;text-anchor:end;fill:none;stroke:#b20938;stroke-width:4;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1"
+     x="40.311707"
+     y="658.68695"
+     id="text39"><tspan
+       id="tspan39"
+       x="40.311707"
+       y="658.68695"
+       style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:26.6667px;font-family:Roboto;-inkscape-font-specification:'Roboto Bold';text-align:start;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none">13</tspan></text>
+  <text
+     xml:space="preserve"
+     style="font-weight:bold;font-size:26.6667px;line-height:1.1;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:end;text-anchor:end;fill:none;stroke:#b20938;stroke-width:4;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1"
+     x="71.514397"
+     y="658.68695"
+     id="text41"><tspan
+       id="tspan41"
+       x="71.514397"
+       y="658.68695"
+       style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:26.6667px;font-family:Roboto;-inkscape-font-specification:'Roboto Bold';text-align:start;text-anchor:start;fill:#8f7e8a;fill-opacity:1;stroke:none">:00</tspan></text>
+  <text
+     xml:space="preserve"
+     style="font-weight:bold;font-size:26.6667px;line-height:1.1;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:end;text-anchor:end;fill:none;stroke:#b20938;stroke-width:4;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1"
+     x="40.311707"
+     y="740.15173"
+     id="text42"><tspan
+       id="tspan42"
+       x="40.311707"
+       y="740.15173"
+       style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:26.6667px;font-family:Roboto;-inkscape-font-specification:'Roboto Bold';text-align:start;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none">14</tspan></text>
+  <text
+     xml:space="preserve"
+     style="font-weight:bold;font-size:26.6667px;line-height:1.1;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:end;text-anchor:end;fill:none;stroke:#b20938;stroke-width:4;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1"
+     x="71.514397"
+     y="740.13873"
+     id="text43"><tspan
+       id="tspan43"
+       x="71.514397"
+       y="740.13873"
+       style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:26.6667px;font-family:Roboto;-inkscape-font-specification:'Roboto Bold';text-align:start;text-anchor:start;fill:#8f7e8a;fill-opacity:1;stroke:none">:00</tspan></text>
+  <text
+     xml:space="preserve"
+     style="font-weight:bold;font-size:26.6667px;line-height:1.1;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:end;text-anchor:end;fill:none;stroke:#b20938;stroke-width:4;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1"
+     x="40.311707"
+     y="821.47339"
+     id="text44"><tspan
+       id="tspan44"
+       x="40.311707"
+       y="821.47339"
+       style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:26.6667px;font-family:Roboto;-inkscape-font-specification:'Roboto Bold';text-align:start;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none">15</tspan></text>
+  <text
+     xml:space="preserve"
+     style="font-weight:bold;font-size:26.6667px;line-height:1.1;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:end;text-anchor:end;fill:none;stroke:#b20938;stroke-width:4;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1"
+     x="71.514397"
+     y="821.59058"
+     id="text45"><tspan
+       id="tspan45"
+       x="71.514397"
+       y="821.59058"
+       style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:26.6667px;font-family:Roboto;-inkscape-font-specification:'Roboto Bold';text-align:start;text-anchor:start;fill:#8f7e8a;fill-opacity:1;stroke:none">:00</tspan></text>
+  <text
+     xml:space="preserve"
+     style="font-weight:bold;font-size:26.6667px;line-height:1.1;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:end;text-anchor:end;fill:none;stroke:#b20938;stroke-width:4;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1"
+     x="40.311707"
+     y="903.00977"
+     id="text46"><tspan
+       id="tspan46"
+       x="40.311707"
+       y="903.00977"
+       style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:26.6667px;font-family:Roboto;-inkscape-font-specification:'Roboto Bold';text-align:start;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none">16</tspan></text>
+  <text
+     xml:space="preserve"
+     style="font-weight:bold;font-size:26.6667px;line-height:1.1;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:end;text-anchor:end;fill:none;stroke:#b20938;stroke-width:4;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1"
+     x="71.514397"
+     y="903.04236"
+     id="text47"><tspan
+       id="tspan47"
+       x="71.514397"
+       y="903.04236"
+       style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:26.6667px;font-family:Roboto;-inkscape-font-specification:'Roboto Bold';text-align:start;text-anchor:start;fill:#8f7e8a;fill-opacity:1;stroke:none">:00</tspan></text>
+  <text
+     xml:space="preserve"
+     style="font-weight:bold;font-size:26.6667px;line-height:1.1;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:end;text-anchor:end;fill:none;stroke:#b20938;stroke-width:4;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1"
+     x="40.311707"
+     y="984.5072"
+     id="text48"><tspan
+       id="tspan48"
+       x="40.311707"
+       y="984.5072"
+       style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:26.6667px;font-family:Roboto;-inkscape-font-specification:'Roboto Bold';text-align:start;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none">17</tspan></text>
+  <text
+     xml:space="preserve"
+     style="font-weight:bold;font-size:26.6667px;line-height:1.1;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:end;text-anchor:end;fill:none;stroke:#b20938;stroke-width:4;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1"
+     x="71.514397"
+     y="984.4942"
+     id="text49"><tspan
+       id="tspan49"
+       x="71.514397"
+       y="984.4942"
+       style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:26.6667px;font-family:Roboto;-inkscape-font-specification:'Roboto Bold';text-align:start;text-anchor:start;fill:#8f7e8a;fill-opacity:1;stroke:none">:00</tspan></text>
+  <text
+     xml:space="preserve"
+     style="font-weight:bold;font-size:26.6667px;line-height:1.1;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:end;text-anchor:end;fill:none;stroke:#b20938;stroke-width:4;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1"
+     x="40.311707"
+     y="1065.946"
+     id="text50"><tspan
+       id="tspan50"
+       x="40.311707"
+       y="1065.946"
+       style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:26.6667px;font-family:Roboto;-inkscape-font-specification:'Roboto Bold';text-align:start;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none">18</tspan></text>
+  <text
+     xml:space="preserve"
+     style="font-weight:bold;font-size:26.6667px;line-height:1.1;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:end;text-anchor:end;fill:none;stroke:#b20938;stroke-width:4;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1"
+     x="71.514397"
+     y="1065.946"
+     id="text51"><tspan
+       id="tspan51"
+       x="71.514397"
+       y="1065.946"
+       style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:26.6667px;font-family:Roboto;-inkscape-font-specification:'Roboto Bold';text-align:start;text-anchor:start;fill:#8f7e8a;fill-opacity:1;stroke:none">:00</tspan></text>
+  <text
+     xml:space="preserve"
+     style="font-weight:bold;font-size:26.6667px;line-height:1.1;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:end;text-anchor:end;fill:none;stroke:#b20938;stroke-width:4;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1"
+     x="40.311707"
+     y="1147.4369"
+     id="text52"><tspan
+       id="tspan52"
+       x="40.311707"
+       y="1147.4369"
+       style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:26.6667px;font-family:Roboto;-inkscape-font-specification:'Roboto Bold';text-align:start;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none">19</tspan></text>
+  <text
+     xml:space="preserve"
+     style="font-weight:bold;font-size:26.6667px;line-height:1.1;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:end;text-anchor:end;fill:none;stroke:#b20938;stroke-width:4;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1"
+     x="71.514397"
+     y="1147.3978"
+     id="text53"><tspan
+       id="tspan53"
+       x="71.514397"
+       y="1147.3978"
+       style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:26.6667px;font-family:Roboto;-inkscape-font-specification:'Roboto Bold';text-align:start;text-anchor:start;fill:#8f7e8a;fill-opacity:1;stroke:none">:00</tspan></text>
+  <text
+     xml:space="preserve"
+     style="font-weight:bold;font-size:26.6667px;line-height:1.1;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:end;text-anchor:end;fill:none;stroke:#b20938;stroke-width:4;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1"
+     x="40.311707"
+     y="1228.8496"
+     id="text54"><tspan
+       id="tspan54"
+       x="40.311707"
+       y="1228.8496"
+       style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:26.6667px;font-family:Roboto;-inkscape-font-specification:'Roboto Bold';text-align:start;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none">20</tspan></text>
+  <text
+     xml:space="preserve"
+     style="font-weight:bold;font-size:26.6667px;line-height:1.1;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:end;text-anchor:end;fill:none;stroke:#b20938;stroke-width:4;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1"
+     x="71.514397"
+     y="1228.8496"
+     id="text55"><tspan
+       id="tspan55"
+       x="71.514397"
+       y="1228.8496"
+       style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:26.6667px;font-family:Roboto;-inkscape-font-specification:'Roboto Bold';text-align:start;text-anchor:start;fill:#8f7e8a;fill-opacity:1;stroke:none">:00</tspan></text>
+  <text
+     xml:space="preserve"
+     style="font-weight:bold;font-size:26.6667px;line-height:1.1;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:end;text-anchor:end;fill:none;stroke:#b20938;stroke-width:4;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1"
+     x="40.311707"
+     y="1310.4315"
+     id="text56"><tspan
+       id="tspan56"
+       x="40.311707"
+       y="1310.4315"
+       style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:26.6667px;font-family:Roboto;-inkscape-font-specification:'Roboto Bold';text-align:start;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none">21</tspan></text>
+  <text
+     xml:space="preserve"
+     style="font-weight:bold;font-size:26.6667px;line-height:1.1;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:end;text-anchor:end;fill:none;stroke:#b20938;stroke-width:4;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1"
+     x="71.514397"
+     y="1310.3014"
+     id="text57"><tspan
+       id="tspan57"
+       x="71.514397"
+       y="1310.3014"
+       style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:26.6667px;font-family:Roboto;-inkscape-font-specification:'Roboto Bold';text-align:start;text-anchor:start;fill:#8f7e8a;fill-opacity:1;stroke:none">:00</tspan></text>
+  <text
+     xml:space="preserve"
+     style="font-weight:bold;font-size:26.6667px;line-height:1.1;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:end;text-anchor:end;fill:none;stroke:#b20938;stroke-width:4;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1"
+     x="40.311707"
+     y="1391.8833"
+     id="text58"><tspan
+       id="tspan58"
+       x="40.311707"
+       y="1391.8833"
+       style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:26.6667px;font-family:Roboto;-inkscape-font-specification:'Roboto Bold';text-align:start;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none">22</tspan></text>
+  <text
+     xml:space="preserve"
+     style="font-weight:bold;font-size:26.6667px;line-height:1.1;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:end;text-anchor:end;fill:none;stroke:#b20938;stroke-width:4;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1"
+     x="71.514397"
+     y="1391.7532"
+     id="text59"><tspan
+       id="tspan59"
+       x="71.514397"
+       y="1391.7532"
+       style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:26.6667px;font-family:Roboto;-inkscape-font-specification:'Roboto Bold';text-align:start;text-anchor:start;fill:#8f7e8a;fill-opacity:1;stroke:none">:00</tspan></text>
+  <text
+     xml:space="preserve"
+     style="font-weight:bold;font-size:26.6667px;line-height:1.1;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:end;text-anchor:end;fill:none;stroke:#b20938;stroke-width:4;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1"
+     x="40.311707"
+     y="1473.2051"
+     id="text60"><tspan
+       id="tspan60"
+       x="40.311707"
+       y="1473.2051"
+       style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:26.6667px;font-family:Roboto;-inkscape-font-specification:'Roboto Bold';text-align:start;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none">23</tspan></text>
+  <text
+     xml:space="preserve"
+     style="font-weight:bold;font-size:26.6667px;line-height:1.1;font-family:Arial;-inkscape-font-specification:'Arial Bold';text-align:end;text-anchor:end;fill:none;stroke:#b20938;stroke-width:4;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1"
+     x="71.514397"
+     y="1473.2051"
+     id="text61"><tspan
+       id="tspan61"
+       x="71.514397"
+       y="1473.2051"
+       style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:26.6667px;font-family:Roboto;-inkscape-font-specification:'Roboto Bold';text-align:start;text-anchor:start;fill:#8f7e8a;fill-opacity:1;stroke:none">:00</tspan></text>
+  <path
+     style="color:#000000;fill:#ffffff;fill-opacity:1;stroke:none;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1;-inkscape-stroke:none"
+     d="m 227.87305,118.77148 c -11.61669,0 -21,9.38331 -21,21 V 1485.4492 c 0,11.6167 9.38331,21 21,21 H 1043 c 11.6167,0 21,-9.3833 21,-21 V 139.77148 c 0,-11.61669 -9.3833,-21 -21,-21 z M 192.87389,104.72179 H 1080 v 0 V 1520 v 0 H 192.87389 v 0 z"
+     id="rect64" />
+</svg>


### PR DESCRIPTION
### Description of changes
The form_schedule function for PIL schedule images has been changed. The previous implementation was removed including attendant functions and replaced with a single svg string. Inside resourses, the template was placed. 
The cairosvg library for svg converting to png was added.

Some function signatures were changed to enable or disable the fill of cells of a schedule image.

_render_keyboard was changed to correct alignment of buttons when all timeslots are visible.

The Roboto font has to be installed on the server!
![image](https://github.com/user-attachments/assets/3ca75f81-a675-4d34-96fc-ae0c12f1c255)
